### PR TITLE
[hamlib] Fix Android pkg-config link flags

### DIFF
--- a/ports/hamlib/fix-android-pkgconfig-libs.patch
+++ b/ports/hamlib/fix-android-pkgconfig-libs.patch
@@ -1,0 +1,45 @@
+diff --git a/configure.ac b/configure.ac
+index 2accf2c..d466348 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -178,13 +178,14 @@ if test "x$have_android" = "xyes"; then
+ 
+     CXXFLAGS="$CXXFLAGS -stdlib=libc++"
+     LDFLAGS="$LDFLAGS -lc++"
++    ANDROID_LIBS="-llog"
+ 
+ fi
+ 
+ if test "x$have_android_sensor" = "xyes"; then
+     AC_DEFINE([HAVE_ANDROID_SENSOR], [1],
+               [Define if Android sensor API is available])
+ 
+-    ANDROID_LIBS="-landroid"
++    ANDROID_LIBS="$ANDROID_LIBS -landroid"
+     ROT_BACKEND_LIST="$ROT_BACKEND_LIST rotators/androidsensor"
+ fi
+ 
+diff --git a/hamlib.pc.in b/hamlib.pc.in
+index 4da24fe..11a596b 100644
+--- a/hamlib.pc.in
++++ b/hamlib.pc.in
+@@ -10,4 +10,4 @@ Version: @PACKAGE_VERSION@
+ Requires.private: @HAMLIB_PC_LIBUSB@
+ Cflags: -I${includedir} @PTHREAD_CFLAGS@
+ Libs: -L${libdir} -lhamlib
+-Libs.private: @MATH_LIBS@ @DL_LIBS@ @NET_LIBS@ @PTHREAD_LIBS@
++Libs.private: @MATH_LIBS@ @DL_LIBS@ @NET_LIBS@ @PTHREAD_LIBS@ @ANDROID_LIBS@
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 115128d..3fa567e 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -24,7 +24,7 @@ libhamlib_la_LDFLAGS = $(WINLDFLAGS) $(OSXLDFLAGS) -no-undefined -version-info
+ 
+ libhamlib_la_LIBADD = $(top_builddir)/lib/libmisc.la $(top_builddir)/security/libsecurity.la \
+-	$(BACKENDEPS) $(RIG_BACKENDEPS) $(ROT_BACKENDEPS) $(AMP_BACKENDEPS) $(NET_LIBS) $(MATH_LIBS) $(LIBUSB_LIBS) $(INDI_LIBS)
+-
++	$(BACKENDEPS) $(RIG_BACKENDEPS) $(ROT_BACKENDEPS) $(AMP_BACKENDEPS) $(NET_LIBS) $(MATH_LIBS) $(LIBUSB_LIBS) $(INDI_LIBS) \
++	$(ANDROID_LIBS)
+ libhamlib_la_DEPENDENCIES = $(top_builddir)/lib/libmisc.la $(top_builddir)/security/libsecurity.la $(BACKENDEPS) $(RIG_BACKENDEPS) $(ROT_BACKENDEPS) $(AMP_BACKENDEPS) 
+ 
+ EXTRA_DIST = hamlibdatetime.h.in band_changed.c

--- a/ports/hamlib/portfile.cmake
+++ b/ports/hamlib/portfile.cmake
@@ -3,6 +3,8 @@ vcpkg_from_github(
     REPO Hamlib/Hamlib
     REF "${VERSION}"
     SHA512 11522382a00f490849a788e8352ac445883f7b86a9fd6f6e17c063721a1a53819f208a21c4b6623d4485946cf9446eccddfee8605d60f96381b4ac7cbee398da
+    PATCHES
+        fix-android-pkgconfig-libs.patch
 )
 
 vcpkg_list(SET options)
@@ -15,10 +17,6 @@ if("xml" IN_LIST FEATURES)
     list(APPEND options --with-xml-support=yes)
 else()
     list(APPEND options --with-xml-support=no)
-endif()
-
-if(VCPKG_TARGET_IS_ANDROID)
-    list(APPEND options "LIBS=\$LIBS -llog")
 endif()
 
 vcpkg_make_configure(

--- a/versions/h-/hamlib.json
+++ b/versions/h-/hamlib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "257574af46f25a046e511d543051c98b5af5f5e8",
+      "git-tree": "818c9eff6c8304e2a6397b629f61b1f341f48c7b",
       "version": "4.7.2",
       "port-version": 1
     },


### PR DESCRIPTION
Patch upstream metadata so Android pkg-config consumers receive the same log and sensor libraries needed by the built package.

This change was written by GPT 5.5.